### PR TITLE
list_set stress_concurrent ops fix

### DIFF
--- a/homework/tests/list_set.rs
+++ b/homework/tests/list_set.rs
@@ -143,7 +143,7 @@ impl Log {
 
 #[test]
 fn stress_concurrent() {
-    let ops = [Ops::Contains, Ops::Insert, Ops::Remove, Ops::Remove];
+    let ops = [Ops::Contains, Ops::Insert, Ops::Remove];
 
     let set = OrderedListSet::new();
 


### PR DESCRIPTION
I was going to send a pull request last semester, but I forgot to send so open it now.

I couldn't find the reason to choose "remove operation" twice than other operations, so i tried to fix.
If this line is intended, maybe some kind of comment would be helpful to understand. Thank you.