### PR TITLE
Add safety proofs for locks, queue and stack.

### DIFF
--- a/src/lock/clhlock.rs
+++ b/src/lock/clhlock.rs
@@ -64,6 +64,8 @@ impl Drop for ClhLock {
     fn drop(&mut self) {
         // Drop the node made by the last thread that `lock()`ed.
         let node = self.tail.load(Ordering::Relaxed);
+
+        // SAFETY: Since this is the tail node, no other thread has access to it.
         drop(unsafe { Box::from_raw(node) });
     }
 }

--- a/src/lockfree/list.rs
+++ b/src/lockfree/list.rs
@@ -168,9 +168,7 @@ where
                 self.prev
                     .compare_exchange(self.curr, next, Ordering::Release, Ordering::Relaxed, guard)
                     .map_err(|_| ())?;
-                unsafe {
-                    guard.defer_destroy(self.curr);
-                }
+                unsafe { guard.defer_destroy(self.curr) };
                 self.curr = next;
                 continue;
             }

--- a/src/lockfree/list.rs
+++ b/src/lockfree/list.rs
@@ -147,7 +147,9 @@ where
                 .unwrap()
                 .next
                 .load(Ordering::Acquire, guard);
-            unsafe { guard.defer_destroy(node) };
+            unsafe {
+                guard.defer_destroy(node);
+            }
             node = next;
         }
 
@@ -168,7 +170,9 @@ where
                 self.prev
                     .compare_exchange(self.curr, next, Ordering::Release, Ordering::Relaxed, guard)
                     .map_err(|_| ())?;
-                unsafe { guard.defer_destroy(self.curr) };
+                unsafe {
+                    guard.defer_destroy(self.curr);
+                }
                 self.curr = next;
                 continue;
             }
@@ -246,7 +250,9 @@ where
             .compare_exchange(self.curr, next, Ordering::Release, Ordering::Relaxed, guard)
             .is_ok()
         {
-            unsafe { guard.defer_destroy(self.curr) };
+            unsafe {
+                guard.defer_destroy(self.curr);
+            }
         }
 
         Ok(&curr_node.value)

--- a/src/lockfree/queue.rs
+++ b/src/lockfree/queue.rs
@@ -162,7 +162,9 @@ impl<T> Queue<T> {
                 // SAFETY: `head` is unreachable, and we no longer access `head`. We destory `head`
                 // after the final access to `next` above to ensure that `next` is also destroyed
                 // after.
-                unsafe { guard.defer_destroy(head) };
+                unsafe {
+                    guard.defer_destroy(head);
+                }
 
                 return Some(result);
             }

--- a/src/lockfree/queue.rs
+++ b/src/lockfree/queue.rs
@@ -150,21 +150,19 @@ impl<T> Queue<T> {
                 // Since the above `compare_exchange()` succeeded, `head` is detached from `self` so
                 // is unreachable from other threads.
 
-                // SAFETY: `next` will never be the sentinal node, since it is the node after
+                // SAFETY: `next` will never be the seninel node, since it is the node after
                 // `head`. Hence, it must have been a node made in `push()`, which is initialized.
                 //
                 // Also, We are returning ownership of `data` in `next` by making a copy of it
                 // via `assume_init_read()`. This is safe as no other thread has access to `data`
                 // after `head` is unreachable, so the ownership of `data` in `next` will never be
-                // used again as it is now a sentinal node.
+                // used again as it is now a seninel node.
                 let result = unsafe { next_ref.data.assume_init_read() };
 
                 // SAFETY: `head` is unreachable, and we no longer access `head`. We destory `head`
                 // after the final access to `next` above to ensure that `next` is also destroyed
                 // after.
-                unsafe {
-                    guard.defer_destroy(head);
-                }
+                unsafe { guard.defer_destroy(head) };
 
                 return Some(result);
             }
@@ -181,7 +179,7 @@ impl<T> Drop for Queue<T> {
 
         // Destroy the remaining sentinel node.
         let sentinel = self.head.load(Ordering::Relaxed, guard);
-        // SAFETY: As `pop()` only drops detached nodes, it never dropped the sentinal node so it is
+        // SAFETY: As `pop()` only drops detached nodes, it never dropped the seninel node so it is
         // still valid.
         drop(unsafe { sentinel.into_owned() });
     }

--- a/src/lockfree/stack.rs
+++ b/src/lockfree/stack.rs
@@ -80,9 +80,8 @@ impl<T> Stack<T> {
                 let result = ManuallyDrop::into_inner(unsafe { ptr::read(&h.data) });
 
                 // SAFETY: `head` is unreachable, and we no longer access `head`.
-                unsafe {
-                    guard.defer_destroy(head);
-                }
+                unsafe { guard.defer_destroy(head) };
+
                 return Some(result);
             }
         }

--- a/src/lockfree/stack.rs
+++ b/src/lockfree/stack.rs
@@ -80,7 +80,9 @@ impl<T> Stack<T> {
                 let result = ManuallyDrop::into_inner(unsafe { ptr::read(&h.data) });
 
                 // SAFETY: `head` is unreachable, and we no longer access `head`.
-                unsafe { guard.defer_destroy(head) };
+                unsafe {
+                    guard.defer_destroy(head);
+                }
 
                 return Some(result);
             }


### PR DESCRIPTION
추가한 내용
- Lock, queue, stack의 safety proof을 추가했습니다.
- list은 먼저 제가 수업에서 쓰는 list 리뷰를 좀 해야 해서 일단은 안 적었습니다.

기타
- clh lock 같은 경우 마지막 lock을 하는 스레드가 만드는 node은 drop을 안하기에 추가를 해줬습니다.
- queue같은 경우 `assume_init_read()`라는 딱 저희 상황에 필요한 API가 Rust 1.60부터 있어서 이걸 썻습니다.