### PR TITLE
Fix minor typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ Make sure you're capable of using the following development tools:
 
 - Place: Rm. 2443, Bldg. E3-1, KAIST
 
-- Your physical apperance is required. If online participation is **absolutely necessary**, we'll use Zoom.
+- Your physical appearance is required. If online participation is **absolutely necessary**, we'll use Zoom.
 
 - You'll bring your own laptop. (You can also borrow one from School of Computing Admin Team.)
 

--- a/homework/scripts/grade-hazard_pointer.sh
+++ b/homework/scripts/grade-hazard_pointer.sh
@@ -88,7 +88,7 @@ done
 # NOTE: We only accept optimal and correct solution.
 # So, if SeqCst > 2, no need to run check-loom test.
 # - This prevents running check-loom on the SC version
-#   (to avoid confusion caused by loom's inability to handle SeqCst acceses.)
+#   (to avoid confusion caused by loom's inability to handle SeqCst accesses.)
 # - This assumes that there is no solution with SeqCst accesses ≤ 2.
 loom_failed=$performance_failed
 if [ "$performance_failed" = false ]; then

--- a/homework/src/bin/hello_server.rs
+++ b/homework/src/bin/hello_server.rs
@@ -34,9 +34,9 @@ fn main() -> io::Result<()> {
     let listener = Arc::new(CancellableTcpListener::bind(ADDR)?);
 
     // Installs a Ctrl-C handler.
-    let ctrlc_listner_handle = listener.clone();
+    let ctrlc_listener_handle = listener.clone();
     ctrlc::set_handler(move || {
-        ctrlc_listner_handle.cancel().unwrap();
+        ctrlc_listener_handle.cancel().unwrap();
     })
     .expect("Error setting Ctrl-C handler");
 

--- a/homework/src/hazard_pointer/hazard.rs
+++ b/homework/src/hazard_pointer/hazard.rs
@@ -134,7 +134,7 @@ impl HazardBag {
         }
     }
 
-    /// Acquires a slot in the hazard set, either by recyling an inactive slot or allocating a new
+    /// Acquires a slot in the hazard set, either by recycling an inactive slot or allocating a new
     /// slot.
     fn acquire_slot(&self) -> &HazardSlot {
         todo!()

--- a/homework/src/map.rs
+++ b/homework/src/map.rs
@@ -46,7 +46,7 @@ pub trait SequentialMap<K: ?Sized, V> {
     // fn insert<'a>(&'a mut self, key: &'a K, value: V) -> Result<&'a mut V, (&'a mut V, V)>;
     fn insert<'a>(&'a mut self, key: &'a K, value: V) -> Result<(), V>;
 
-    /// Delets a key, returning the value.
+    /// Deletes a key, returning the value.
     fn delete(&mut self, key: &K) -> Result<V, ()>;
 }
 
@@ -72,7 +72,7 @@ pub trait NonblockingMap<K: ?Sized, V> {
     /// Inserts a key-value pair.
     fn insert(&self, key: &K, value: V, guard: &Guard) -> Result<(), V>;
 
-    /// Deletes the given key and retruns a reference to its value.
+    /// Deletes the given key and returns a reference to its value.
     ///
     /// Unlike stack or queue's pop that can return `Option<V>`, since a `delete`d
     /// value may also be `lookup`ed, we can only return a reference, not full ownership.

--- a/homework/tests/list_set.rs
+++ b/homework/tests/list_set.rs
@@ -149,7 +149,7 @@ fn stress_concurrent() {
 
     thread::scope(|s| {
         for _ in 0..THREADS {
-            let _ununsed = s.spawn(|| {
+            let _unused = s.spawn(|| {
                 let mut rng = thread_rng();
                 for _ in 0..STEPS {
                     let op = ops.choose(&mut rng).unwrap();

--- a/src/lockfree/list.rs
+++ b/src/lockfree/list.rs
@@ -18,7 +18,7 @@ pub struct Node<K, V> {
 /// Sorted singly linked list.
 ///
 /// Use-after-free will be caused when an unprotected guard is used, as the lifetime of returned
-/// elments are linked to that of the guard in the same way a `Shared<'g,T>` is.
+/// elements are linked to that of the guard in the same way a `Shared<'g,T>` is.
 #[derive(Debug)]
 pub struct List<K, V> {
     head: Atomic<Node<K, V>>,
@@ -248,8 +248,8 @@ where
         // SAFETY: curr was found, hence cannot be null.
         let curr_node = unsafe { self.curr.deref() };
 
-        // Release: to relase current view of the deleting thread on this mark.
-        // Acquire: to ensure that if the latter CAS succeds, then the thread that reads `next` through `prev` will be safe.
+        // Release: to release current view of the deleting thread on this mark.
+        // Acquire: to ensure that if the latter CAS succeeds, then the thread that reads `next` through `prev` will be safe.
         let next = curr_node.next.fetch_or(1, Ordering::AcqRel, guard);
         if next.tag() == 1 {
             return Err(());


### PR DESCRIPTION
This revision includes:
- Fix minor typos
  - elments -> elements
  - relase -> release
  - apperance -> appearance
  - _ununsed -> _unused
  - Delets -> Deletes
  - recyling -> recycling
  - visted -> visited
  - listner -> listener
  - acceses -> accesses