### PR TITLE
Fix file path in doc of homework 1

### DIFF
--- a/homework/doc/hello_server.md
+++ b/homework/doc/hello_server.md
@@ -14,7 +14,7 @@
 - `../src/hello_server/*.rs`: the server components. You should fill out `todo!()` in those files.
 
 ## Grading
-The grader runs `./script/grade-hello_server.sh` in the `homework` directory.
+The grader runs `./scripts/grade-hello_server.sh` in the `homework` directory.
 This script runs the tests with various options.
 
 There will be no partial scores for each module.


### PR DESCRIPTION
Hello :)
I'm a student currently enrolled in CS431 this semester.
I noticed a minor typo in the file path of the Homework 1 document.
You can find the referenced file here:
https://github.com/kaist-cp/cs431/blob/main/homework/scripts/grade-hello_server.sh

This is the only typo of its kind. There aren't any other `**/script/**` elsewhere.

I'd appreciate it if you could review this PR.
Thank you! :)